### PR TITLE
feat: Use the default locale from the user browser

### DIFF
--- a/ui/src/js/lib/store.js
+++ b/ui/src/js/lib/store.js
@@ -25,7 +25,7 @@ const persistantState = reactive({
             selected: {id: null, name: ''},
         },
     },
-    language: {id: 'en'},
+    language: {id: ['en', 'fr', 'nl'].includes(window.navigator.language.split("-")[0]) ? window.navigator.language.split("-")[0] : 'en'},
     loading: true,
     media: {
         accept: {id: 'everything', name: ''},


### PR DESCRIPTION
Instead of defaulting to english, default to the user browser locale when selecting the UI locale at the first user connection.

Fixes #110 