### PR TITLE
fix: Guest users should be able to raise their hand

### DIFF
--- a/ui/src/vue/Conference/Controls/Controls.vue
+++ b/ui/src/vue/Conference/Controls/Controls.vue
@@ -32,7 +32,7 @@
             </button>
 
             <button
-                v-if="$s.group.connected && $s.permissions.present"
+                v-if="$s.group.connected"
                 class="btn btn-menu"
                 :class="{active: $s.user.data.raisehand}"
                 @click="toggleRaiseHand"


### PR DESCRIPTION
In Galene, guest and anonymous users can raise and unraise their hand;
it isn't a privilege of presenters.

This change makes Pyrite match this behavior.