### PR TITLE
fix: Allow re-enabling the camera after both mic and camera are off

### DIFF
--- a/ui/src/js/models/media.js
+++ b/ui/src/js/models/media.js
@@ -30,6 +30,7 @@ export async function getUserMedia(presence) {
         if (!presence.mic.enabled) selectedAudioDevice = false
         // A local stream cannot be initialized with neither audio and video; return early.
         if (!presence.cam.enabled && !presence.mic.enabled) {
+            app.$s.mediaReady = true
             return
         }
     }
@@ -59,6 +60,7 @@ export async function getUserMedia(presence) {
         localStream = await navigator.mediaDevices.getUserMedia(constraints)
     } catch (message) {
         app.notifier.notify({level: 'error', message})
+        app.$s.mediaReady = true
         return
     }
 

--- a/ui/src/vue/Conference/Groups/Group/Controls.vue
+++ b/ui/src/vue/Conference/Groups/Group/Controls.vue
@@ -128,7 +128,14 @@ export default {
             this.app.store.save()
         },
         toggleMicrophone() {
+            let shouldRestartStream = !this.$s.devices.cam.enabled
             this.$m.sfu.muteMicrophone(this.$s.devices.mic.enabled)
+            if (shouldRestartStream) {
+                // When both the camera is off, toggling the microphone should also restart the stream.
+                // Otherwise, we would either continue to stream empty data (when both camera and mic are
+                // off), or we would not send our audio stream altogether.
+                this.$m.media.getUserMedia(this.$s.devices)
+            }
         },
         togglePlayFile(file) {
             if (file) {


### PR DESCRIPTION
Before this change, if both the camera and the microphone were turned
off, Pyrite prevented the user from re-enabling their camera.

This change continues to address problems around issue #106.