### PR TITLE
fix: Correct state when a guest becomes presenter

### DIFF
--- a/ui/src/vue/Conference/Groups/Group/Controls.vue
+++ b/ui/src/vue/Conference/Groups/Group/Controls.vue
@@ -160,6 +160,9 @@ export default {
         '$s.devices.mic.enabled'(enabled) {
             this.$m.sfu.connection.userAction('setdata', this.$m.sfu.connection.id, {mic: enabled})
         },
+        '$s.permissions.present'() {
+            this.$m.media.getUserMedia(this.$s.devices)
+        },
         volume(volume) {
             for (const description of this.$s.streams) {
                 // Only downstreams have volume control:


### PR DESCRIPTION
Before: when a guest becomes a presenter, its microphone and camera are
set "on" in the right hand bar (if they were set "on" on the login
screen), but no upstream is started.

After: when a guest becomes a presenter, if they have set their camera
and/or microphone as "on", their upstream starts immediately. It stops
when they stop being a presenter.